### PR TITLE
Windows directory path compatibility fix (AKA not working)

### DIFF
--- a/src/HotReloader.php
+++ b/src/HotReloader.php
@@ -47,7 +47,7 @@ class HotReloader {
      * @return URL {String} Url to phrwatcher.php file with params
      */
     private function getWatcherFileURL() {
-        return $this->WATCHER_FILE_URL . "?watch=true&reloader_root=" . dirname(__DIR__);
+        return $this->WATCHER_FILE_URL . "?watch=true&reloader_root=" . addslashes(dirname(__DIR__));
     }
 
     /**


### PR DESCRIPTION
HotReloader sends directory path to phrwatcher.php, but Windows' slashes break the string and ultimately you get errors instead of the response. Browser console outputs the following:
"EventSource's response has a MIME type ("text/html") that is not "text/event-stream". Aborting the connection." and nothing else happens.

No idea if addslashes breaks things on other systems, but PHR seems to work on my system now. 