### PR TITLE
Windows git changes

### DIFF
--- a/src/HotReloaderSSE.php
+++ b/src/HotReloaderSSE.php
@@ -42,7 +42,7 @@
 
     // --------------------------------------------
 
-    $Differ = new HotReloaderDiffChecker([
+    $Differ = new DiffChecker([
         'ROOT'     => $PROJECT_ROOT,
         'WATCH'    => $WATCH,
         'IGNORE'   => $IGNORE


### PR DESCRIPTION
Couple of issues related to how shell exec works on Windows, how git outputs changed files and most importantly - what to do when neither the ROOT has a trailing slash (breaks git), nor the added files with relative paths have starting slashes.

Oh, and some stuff PhpStorm complained (class doesn't match filename and lowercase arrays in phpdoc).