### PR TITLE
Included files

### DIFF
--- a/phrwatcher.php
+++ b/phrwatcher.php
@@ -23,10 +23,10 @@
 
 
 	/**
-	 * For additional security, input your IP address to allow this script
+	 * For additional security, input your development site address, to recognize in case of accidental migration into production
 	 */
-	if ( ! in_array( $_SERVER['REMOTE_ADDR'], ['localhost', '127.0.0.1', '::1', '123.123.123.123'] ) ) 
-		exit( "Your IP is not allowed" );
+	if ( ! in_array( $_SERVER['HTTP_HOST'], ['localhost', '127.0.0.1', '::1', 'test.example.com'] ) ) 
+		exit( "{$_SERVER['HTTP_HOST']} does not seem your development server" );
 
 	/**
 	 * This variable must contain your project root absolute

--- a/phrwatcher.php
+++ b/phrwatcher.php
@@ -23,6 +23,12 @@
 
 
 	/**
+	 * For additional security, input your IP address to allow this script
+	 */
+	if ( ! in_array( $_SERVER['REMOTE_ADDR'], ['localhost', '127.0.0.1', '::1', '123.123.123.123'] ) ) 
+		exit( "Your IP is not allowed" );
+
+	/**
 	 * This variable must contain your project root absolute
 	 * path with a trailing slash. The Watch and Ignore paths
 	 * will be relative to this one.

--- a/phrwatcher.php
+++ b/phrwatcher.php
@@ -62,6 +62,4 @@
 
 	// ---------------------- Dont Edit It ----------------------
 
-	$RELOADER_ROOT = @$_REQUEST["reloader_root"];
-	
-	require_once $RELOADER_ROOT . "/src/HotReloaderSSE.php"; 
+	require_once @$_REQUEST["reloader_root"] . "/src/HotReloaderSSE.php"; 

--- a/phrwatcher.php
+++ b/phrwatcher.php
@@ -44,9 +44,16 @@
 	 * that you want to watch. The application will be reloaded
 	 * when detected some change on those references. All the
 	 * paths must be relative to $PROJECT_ROOT var.
+	 *
+	 * Note:
+	 *  1) if you want to watch specific files, then list them in the array
+	 *  2) if you want to watch the whole root, input the "."
+	 *  3) if you want to watch only the related files to the page you have opened in the 
+	 *        browser, set the array empty. This is the best approach in most cases. However, 
+	 *        if you will experience some glitches (if you app is complex), then use 2nd approach.
 	 */
 	$WATCH = [
-		"."
+		
 	];
 
 	/**

--- a/phrwatcher.php
+++ b/phrwatcher.php
@@ -25,8 +25,12 @@
 	/**
 	 * For additional security, input your development site address, to recognize in case of accidental migration into production
 	 */
-	if ( ! in_array( $_SERVER['HTTP_HOST'], ['localhost', '127.0.0.1', '::1', 'test.example.com'] ) ) 
-		exit( "{$_SERVER['HTTP_HOST']} does not seem your development server" );
+	$ENABLED_HOSTS = [
+		'localhost', 		// localhost
+		'127.0.0.1', 		// localhost alternative
+		'::1', 				// localhost alternative
+		'test.example.com'	// your specific test domain
+	];
 
 	/**
 	 * This variable must contain your project root absolute
@@ -59,12 +63,5 @@
 	// ---------------------- Dont Edit It ----------------------
 
 	$RELOADER_ROOT = @$_REQUEST["reloader_root"];
-
-	if (!empty(@$_REQUEST['watch'])) {
-		if ($ENABLED) {
-			require_once $RELOADER_ROOT . "/src/HotReloaderSSE.php";
-		}
-	} else {
-		echo "SSE_ADDRESS_OK | PROJECT ROOT: <br/>";
-		echo "<b>" . $PROJECT_ROOT . "</b>";
-	}
+	
+	require_once $RELOADER_ROOT . "/src/HotReloaderSSE.php"; 

--- a/src/HotReloader.php
+++ b/src/HotReloader.php
@@ -37,15 +37,20 @@ class HotReloader {
      * @return void
      */
     public function init () {
-		// check if session existed already, not to re-start
-		if( session_status() == PHP_SESSION_NONE ){
-			$this->initiated=true;
-			session_start();
-		}
-		
+		 
 		register_shutdown_function( function(){ 
 			$this->addJSClient();
 		});
+		
+		// if project-dir was set, then user expressed the wish to use the "auto-detected" files list
+		if ( !empty ( $this->PROJECT_DIR ) )
+		{
+			// check if session existed already, not to re-start
+			if( session_status() == PHP_SESSION_NONE ){
+				$this->initiated=true;
+				session_start();
+			}
+		}
     }
 
     /**

--- a/src/HotReloader.php
+++ b/src/HotReloader.php
@@ -93,7 +93,7 @@ class HotReloader {
 		$_SESSION[ $this->random_session_id ] = $final_string;
 		// if we started session, then end it
 		if ( isset ( $this->initiated ) ) {
-			session_write_close();
+			session_destroy();
 		}
 		return "&fileslist=" . $this->random_session_id;
     }

--- a/src/HotReloader.php
+++ b/src/HotReloader.php
@@ -69,6 +69,12 @@ class HotReloader {
 			return '';
 		
 		$included_files = get_included_files();
+		// if fatal/other error stops page execution, then include that file too (as those files are not included in "get_included_files")
+		$last_error = error_get_last();
+		if ( ! empty( $last_error ) && ! empty( $last_error['file'] ) ){
+			$included_files[] = $last_error['file'];
+		}
+		
 		$included_files = array_map( function($filePath) {
 			$standartized_path = $this->standartize_path( $filePath ); 
 			// We only looking for the files which are inside the project_dir (removing the pre-path)

--- a/src/HotReloaderSSE.php
+++ b/src/HotReloaderSSE.php
@@ -33,6 +33,14 @@
 		exit;
 	}
 
+	// Auto-resolve the WATCH list.
+	if ( empty($WATCH) && isset($_REQUEST['fileslist']) )
+	{
+		$files_list = session_get_value($_REQUEST['fileslist']);
+		$list_of_files = explode(',', urldecode( $files_list) );
+		$WATCH = $list_of_files;
+	}
+
 	// Start script
 	
     ob_end_clean();
@@ -48,7 +56,21 @@
     header('Access-Control-Allow-Methods: GET');
     header('Access-Control-Expose-Headers: X-Events');
 
-
+	function session_get_value( $name ){
+		// check if session existed already, not to re-start
+		if( session_status() == PHP_SESSION_NONE ){
+			$initiated=true;
+			session_start();
+		}
+		
+		$value = $_SESSION[ $name ];
+		// if we started session, then end it
+		if ( isset ( $initiated ) ) {
+			session_write_close();
+		}
+		return $value;
+	}
+	
 	function send_message ($message) {
         echo "data: " . json_encode($message) . PHP_EOL;
         echo PHP_EOL;

--- a/src/HotReloaderSSE.php
+++ b/src/HotReloaderSSE.php
@@ -18,6 +18,23 @@
      * @license    https://opensource.org/licenses/mit-license.php MIT License
      */
 
+	
+	// Check if it was enabled
+	if (!$ENABLED){
+		exit("Not Enabled");	
+	}
+	// Check if host is allowed
+	if ( ! in_array( $_SERVER['HTTP_HOST'], $ENABLED_HOSTS ) ) 
+		exit( sprintf("%s does not seem your development server", $_SERVER['HTTP_HOST']) );
+		
+	if ( empty(@$_REQUEST['watch']) ) {
+		echo "SSE_ADDRESS_OK | PROJECT ROOT: <br/>";
+		echo "<b>" . $PROJECT_ROOT . "</b>";
+		exit;
+	}
+
+	// Start script
+	
     ob_end_clean();
     set_time_limit(0);
 
@@ -30,6 +47,7 @@
     header('Content-Type: text/event-stream');
     header('Access-Control-Allow-Methods: GET');
     header('Access-Control-Expose-Headers: X-Events');
+
 
 	function send_message ($message) {
         echo "data: " . json_encode($message) . PHP_EOL;


### PR DESCRIPTION
It would be nice if the script had a feature to reload the current page, only if any of the related files (which have been used while generating the current page) is changed (as opposed to "any" file change in the project dir, or manually setting the "watch-files" list).

To achieve that, it should have been done the following way:

1) If user wants to use that approach, he should set the project_dir in the initializer, like: `new HotReloader\HotReloader('//localhost/'',  __DIR__ )` 
2) Then, in "register_shutdown_hook" (when injecting EVENT_SOURCE_ENDPOINT codes in HTML), it should get all files that were involved in page execution, using `get_included_files()`.
3) Due to possible large-list of included files, instead of query, send the data with Session-ids.
4) in `phrwatcher`, make `fileslist` parameter into array and check if the changed file's path is in that array. If so, send reload signal, otherwise don't send.


This will save much of  unnecessary reloads, while we work on the project ALL OPEN TABS are reloaded, when only one file (related to specific page) changes, and it looses all the Client-Side changes on all tabs (i.e. filled forms, JavaScript actions and states on UI), which are not necessary to have changed. 
So, this will solve the problem and increase the efficiency.